### PR TITLE
set N_GSPS for forecast blend after national-xg

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -76,9 +76,6 @@ forecast_blender = ContainerDefinition(
     container_memory=1024,
 )
 
-forecast_blender_national = forecast_blender
-forecast_blender_national.container_env["N_GSPS"] = "1"
-
 @dag(
     dag_id="uk-gsp-forecast",
     description=__doc__,
@@ -188,8 +185,9 @@ def national_forecast_dayahead_dag() -> None:
 
     blend_forecasts_op = EcsAutoRegisterRunTaskOperator(
         airflow_task_id="blend-forecasts",
-        container_def=forecast_blender_national,
+        container_def=forecast_blender,
         max_active_tis_per_dag=10,
+        env_overrides={"N_GSPS": "1"},
         on_failure_callback=slack_message_callback(
             "❌ The task {{ ti.task_id }} failed."
             "The blending of forecast has failed. "

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -76,6 +76,9 @@ forecast_blender = ContainerDefinition(
     container_memory=1024,
 )
 
+forecast_blender_national = forecast_blender
+forecast_blender_national.container_env["N_GSPS"] = "1"
+
 @dag(
     dag_id="uk-gsp-forecast",
     description=__doc__,
@@ -185,7 +188,7 @@ def national_forecast_dayahead_dag() -> None:
 
     blend_forecasts_op = EcsAutoRegisterRunTaskOperator(
         airflow_task_id="blend-forecasts",
-        container_def=forecast_blender,
+        container_def=forecast_blender_national,
         max_active_tis_per_dag=10,
         on_failure_callback=slack_message_callback(
             "❌ The task {{ ti.task_id }} failed."

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -67,7 +67,7 @@ national_forecaster = ContainerDefinition(
 forecast_blender = ContainerDefinition(
     name="forecast-blend",
     container_image="docker.io/openclimatefix/uk_pv_forecast_blend",
-    container_tag="1.0.7",
+    container_tag="1.0.8",
     container_env={"LOGLEVEL": "INFO"},
     container_secret_env={
         f"{env}/rds/forecast/": ["DB_URL"],


### PR DESCRIPTION
# Pull Request

## Description

- only run blend on national after running forecast national-xg

## How Has This Been Tested?

- [ ] TODO

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
