### PR TITLE
India forecast errors to warnings, no out-of-hrs support

### DIFF
--- a/src/airflow_dags/dags/india/consume-nwp-dag.py
+++ b/src/airflow_dags/dags/india/consume-nwp-dag.py
@@ -71,10 +71,11 @@ def nwp_consumer_dag() -> None:
         },
         max_active_tis_per_dag=10,
         on_failure_callback=slack_message_callback(
-            "❌ The task {{ ti.task_id }} failed."
+            "⚠️ The task {{ ti.task_id }} failed. "
             "The forecast will continue running until it runs out of data. "
-            "ECMWF status link is <https://status.ecmwf.int/|here> "
-            "Please see run book for appropriate actions. ",
+            "ECMWF status link is <https://status.ecmwf.int/|here>. "
+            "No out-of-hours support is required at the moment. "
+            "Please see run book for appropriate actions.",
         ),
     )
 
@@ -87,10 +88,11 @@ def nwp_consumer_dag() -> None:
             "ZARRDIR": f"s3://india-nwp-{env}/gfs/data",
         },
         on_failure_callback=slack_message_callback(
-            "❌ The task {{ ti.task_id }} failed. "
+            "⚠️ The task {{ ti.task_id }} failed. "
             "The forecast will continue running until it runs out of data. "
             "GFS status link is "
             "<https://www.nco.ncep.noaa.gov/pmb/nwprod/prodstat/|here>. "
+            "No out-of-hours support is required at the moment. "
             "Please see run book for appropriate actions.",
         ),
     )
@@ -105,10 +107,11 @@ def nwp_consumer_dag() -> None:
             "ZARRDIR": f"s3://india-nwp-{env}/metoffice/data",
         },
         on_failure_callback=slack_message_callback(
-            "❌ The task {{ ti.task_id }} failed. "
+            "⚠️ The task {{ ti.task_id }} failed. "
             "The forecast will continue running until it runs out of data. "
             "Metoffice status link is "
             "<https://datahub.metoffice.gov.uk/support/service-status|here>. "
+            "No out-of-hours support is required at the moment. "
             "Please see run book for appropriate actions.",
         ),
     )
@@ -130,4 +133,3 @@ def nwp_consumer_dag() -> None:
     latest_only_op >> consume_metoffice_op >> rename_zarr_metoffice
 
 nwp_consumer_dag()
-

--- a/src/airflow_dags/dags/india/consume-sat-dag.py
+++ b/src/airflow_dags/dags/india/consume-sat-dag.py
@@ -62,10 +62,11 @@ def sat_consumer_dag() -> None:
         container_def=satellite_consumer,
         max_active_tis_per_dag=10,
         on_failure_callback=slack_message_callback(
-            "❌ The task {{ ti.task_id }} failed."
+            "⚠️ The task {{ ti.task_id }} failed. "
             "EUMETSAT status links are <https://uns.eumetsat.int/uns/|here> "
             "and <https://masif.eumetsat.int/ossi/webpages/level2.html?"
             "ossi_level2_filename=seviri_iodc.html|here>. "
+            "No out-of-hours support is required at the moment. "
             "Please see run book for appropriate actions.",
         ),
     )

--- a/src/airflow_dags/dags/india/forecast-site-dag.py
+++ b/src/airflow_dags/dags/india/forecast-site-dag.py
@@ -65,8 +65,9 @@ def ruvnl_forecast_dag() -> None:
             "USE_SATELLITE": "False",
         },
         on_failure_callback=slack_message_callback(
-            "❌ The task {{ ti.task_id }} failed. "
-            "This would ideally be fixed before for DA actions at 09.00 IST"
+            "⚠️ The task {{ ti.task_id }} failed. "
+            "This would ideally be fixed before for DA actions at 09.00 IST. "
+            "No out-of-hours support is required at the moment. "
             "Please see run book for appropriate actions.",
         ),
     )
@@ -95,8 +96,9 @@ def ad_forecast_dag() -> None:
             "SAVE_BATCHES_DIR": f"s3://india-forecast-{env}/ad",
         },
         on_failure_callback=slack_message_callback(
-            "❌ The task {{ ti.task_id }} failed.  "
-            "Please see run book for appropriate actions. ",
+            "⚠️ The task {{ ti.task_id }} failed. "
+            "No out-of-hours support is required at the moment. "
+            "Please see run book for appropriate actions.",
         ),
         max_active_tis_per_dag=10,
     )
@@ -105,4 +107,3 @@ def ad_forecast_dag() -> None:
 
 ruvnl_forecast_dag()
 ad_forecast_dag()
-


### PR DESCRIPTION
# Pull Request

## Description

I've made the following changes to the `forecast-site-dag.py` file:

1. Changed the error emoji from "❌" to "⚠️" to indicate warnings instead of errors
2. Added the message "No out-of-hours support is required at the moment." to both failure callbacks
3. Fixed a minor spacing issue in the RUVNL message

In `consume-nwp-dag.py`:

1. Changed the error emoji from "❌" to "⚠️" in all three failure callbacks (ECMWF, GFS, and Metoffice)
2. Added the message "No out-of-hours support is required at the moment." to all three failure callbacks
3. Added a period after the status link URL in the ECMWF message for consistency


In `consume-sat-dag.py:`

1. Changed the error emoji from "❌" to "⚠️" in the failure callback
2. Added the message "No out-of-hours support is required at the moment." to the failure callback

Fixes #91 

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
