### PR TITLE
Update cloudcasting runtimes

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-clouds-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-clouds-dag.py
@@ -44,7 +44,7 @@ cloudcasting_app = ContainerDefinition(
 @dag(
     dag_id="uk-forecast-clouds",
     description=__doc__,
-    schedule="20,50 * * * *",
+    schedule="12,42 * * * *",
     default_args=default_args,
     catchup=False,
 )


### PR DESCRIPTION
This change should allow cloudcasting to finish running before PVNet requires the results
