### PR TITLE
Failure callback pvnet intraday

### DIFF
--- a/src/airflow_dags/dags/india/forecast-site-dag.py
+++ b/src/airflow_dags/dags/india/forecast-site-dag.py
@@ -27,7 +27,7 @@ default_args = {
 india_forecaster = ContainerDefinition(
     name="forecast",
     container_image="docker.io/openclimatefix/india_forecast_app",
-    container_tag="1.1.38",
+    container_tag="1.1.39",
     container_env={
         "NWP_GFS_ZARR_PATH": f"s3://india-nwp-{env}/gfs/data/latest.zarr",
         "NWP_MO_GLOBAL_ZARR_PATH": f"s3://india-nwp-{env}/metoffice/data/latest.zarr",

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -77,13 +77,12 @@ forecast_blender = ContainerDefinition(
 )
 
 
-def on_failure_callback_pvnet_intraday(context):
+def on_failure_callback_pvnet_intraday(context: dict) -> None:
     """Callback for PVNet intraday failures.
 
-    By default, a error message is sent to slack.
+    By default, an error message is sent to slack.
     If PVNET_ECMWF only model has run, a warning message is sent to slack.
     """
-
     message = (
         "❌ The task {{ ti.task_id }} failed. "
         "This means one or more of the critical PVNet models have failed to run. "
@@ -96,7 +95,7 @@ def on_failure_callback_pvnet_intraday(context):
         # Completed forecasts: ['pvnet_ecmwf', 'pvnet-ukv-only']"
         #
         # we want to extract the model names from the exception message
-        failed_models = str(exception).split(":")[1].strip("Completed forecasts")
+        failed_models = str(exception).split(":")[1].replace("Completed forecasts", "")
         successful_models = str(exception).split(":")[2]
 
         if "pvnet_ecmwf " in successful_models:

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -114,7 +114,7 @@ def on_failure_callback_pvnet_intraday(context: dict) -> None:
                 "Please see run book for appropriate actions."
             )
 
-    slack_message_callback(message)(context=context)
+    slack_message_callback(message)
 
 
 @dag(


### PR DESCRIPTION
# Pull Request

## Description

Add bespoke message to for PVNet Intraday failure. 
Only give warning, if PVNet_ECWMF did run, error if note

## How Has This Been Tested?

- [x] CI tests
- [ ] run on dev


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
