### PR TITLE
Release/1.1 #minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ Many of OCF's production services run as batch pipelines managed by an Airflow d
 This repo defines those airflow DAGs that configure, version control, and test these pipelines,
 and handles the deployment process.
 
+## Releases
+
+### 1.1.0
+
+- Update PVLive consumer to use on prem server - from `1.2.5` to `1.2.6`. 
+- Trigger blend service, even if PVnet fails
+- Tidy PVnet App docs -`2.5.15` to `2.5.16`
+- India forecast app to save probabilistic values - `1.1.34` to `1.1.39`
+- Upgrade Cloudcasting app - `0.0.7` to `0.0.8`
+
+### 1.0
+
+Initial release
+
 
 ## Installation
 

--- a/src/airflow_dags/dags/uk/consume-sat-dag.py
+++ b/src/airflow_dags/dags/uk/consume-sat-dag.py
@@ -152,7 +152,7 @@ def sat_consumer_dag() -> None:
     )
 
     latest_only_op >> satip_consume >> update_5min_op >> update_15min_op
-    latest_only_op >> consume_rss_op >> consume_iodc_op
+    # latest_only_op >> consume_rss_op >> consume_iodc_op
 
 @dag(
     dag_id="uk-manage-clean-sat",

--- a/src/airflow_dags/dags/uk/consume-sat-dag.py
+++ b/src/airflow_dags/dags/uk/consume-sat-dag.py
@@ -118,7 +118,7 @@ def sat_consumer_dag() -> None:
     update_5min_op = update_operator(cadence_mins=5)
     update_15min_op = update_operator(cadence_mins=15)
 
-    consume_rss_op = EcsAutoRegisterRunTaskOperator(
+    consume_rss_op = EcsAutoRegisterRunTaskOperator( # noqa
        airflow_task_id="consume-rss",
         container_def=sat_consumer,
         env_overrides={
@@ -129,7 +129,7 @@ def sat_consumer_dag() -> None:
             "SATCONS_WORKDIR": f"s3://nowcasting-sat-{env}/testdata/rss",
         },
     )
-    consume_iodc_op = EcsAutoRegisterRunTaskOperator(
+    consume_iodc_op = EcsAutoRegisterRunTaskOperator( # noqa
        airflow_task_id="consume-odegree",
         container_def=sat_consumer,
         trigger_rule=TriggerRule.ALL_FAILED, # Only run if rss fails

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -67,7 +67,7 @@ national_forecaster = ContainerDefinition(
 forecast_blender = ContainerDefinition(
     name="forecast-blend",
     container_image="docker.io/openclimatefix/uk_pv_forecast_blend",
-    container_tag="1.1.1",
+    container_tag="1.0.8",
     container_env={"LOGLEVEL": "INFO"},
     container_secret_env={
         f"{env}/rds/forecast/": ["DB_URL"],


### PR DESCRIPTION
# Pull Request

## Description

- Update PVLive consumer to use on prem server - from `1.2.5` to `1.2.6`. 
- Trigger blend service, even if PVnet fails
- Tidy PVnet App docs -`2.5.15` to `2.5.16`
- India forecast app to save probabilistic values - `1.1.34` to `1.1.39`. Database migration needed. 
- Upgrade Cloudcasting app - `0.0.7` to `0.0.8`

roll back
- blend service
- satellite new consumer

## How Has This Been Tested?

- [ ] CI tests

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
