### PR TITLE
Split metrics DAG into two; bump container to 1.2.23 (#138)

### DIFF
--- a/src/airflow_dags/dags/uk/metrics-dag.py
+++ b/src/airflow_dags/dags/uk/metrics-dag.py
@@ -2,7 +2,6 @@
 
 import datetime as dt
 import os
-import platform
 from datetime import timedelta
 
 from airflow.decorators import dag
@@ -51,21 +50,23 @@ metrics_calculator = ContainerDefinition(
     default_args=default_args,
 )
 def metrics_dag() -> None:
+    """Run the metrics DAG"""
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-metrics",
         container_def=metrics_calculator,
         container_env={
             "USE_PVNET_GSP_SUM": "true",
             "RUN_METRICS": "true",  # Explicitly enable metrics
-            "RUN_ME": "false",      # Disable ME calculations
+            "RUN_ME": "false",  # Disable ME calculations
             "LOGLEVEL": "DEBUG",
         },
-        on_failure_callback=slack_message_callback( 
+        on_failure_callback=slack_message_callback(
             "⚠️ The task {{ ti.task_id }} failed,"
             " but its ok. This task is not critical for live services. "
             "No out of hours support is required.",
         ),
     )
+
 
 # New ME Calculations DAG
 @dag(
@@ -77,21 +78,23 @@ def metrics_dag() -> None:
     default_args=default_args,
 )
 def me_dag() -> None:
+    """Run the ME DAG, used by the adjuster"""
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-me",
         container_def=metrics_calculator,
         container_env={
             "USE_PVNET_GSP_SUM": "true",
             "RUN_METRICS": "false",  # Disable metrics
-            "RUN_ME": "true",       # Enable ME calculations
+            "RUN_ME": "true",  # Enable ME calculations
             "LOGLEVEL": "DEBUG",
         },
-        on_failure_callback=slack_message_callback(  
+        on_failure_callback=slack_message_callback(
             "⚠️ The task {{ ti.task_id }} failed,"
             " but its ok. This task is not critical for live services. "
             "No out of hours support is required.",
         ),
     )
+
 
 # Register both DAGs
 metrics_dag()

--- a/src/airflow_dags/dags/uk/metrics-dag.py
+++ b/src/airflow_dags/dags/uk/metrics-dag.py
@@ -40,7 +40,6 @@ metrics_calculator = ContainerDefinition(
     container_memory=512,
 )
 
-# Original Metrics DAG (unchanged except for env vars)
 @dag(
     dag_id="uk-analysis-metrics",
     description="DAG to calculate metrics from the forecast.",
@@ -68,9 +67,8 @@ def metrics_dag() -> None:
     )
 
 
-# New ME Calculations DAG
 @dag(
-    dag_id="uk-analysis-me",
+    dag_id="uk-analysis-metrics-me",
     description="DAG to run ME calculations for the adjuster.",
     schedule="0 20 * * *",  # 20:00 UTC (1 hour earlier)
     start_date=dt.datetime(2025, 3, 1, tzinfo=dt.UTC),
@@ -80,7 +78,7 @@ def metrics_dag() -> None:
 def me_dag() -> None:
     """Run the ME DAG, used by the adjuster."""
     EcsAutoRegisterRunTaskOperator(
-        airflow_task_id="calculate-me",
+        airflow_task_id="calculate-metrics-me",
         container_def=metrics_calculator,
         env_overrides={
             "USE_PVNET_GSP_SUM": "true",

--- a/src/airflow_dags/dags/uk/metrics-dag.py
+++ b/src/airflow_dags/dags/uk/metrics-dag.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import os
+import platform
 from datetime import timedelta
 
 from airflow.decorators import dag
@@ -27,7 +28,7 @@ default_args = {
 metrics_calculator = ContainerDefinition(
     name="metrics",
     container_image="docker.io/openclimatefix/nowcasting_metrics",
-    container_tag="1.2.22",
+    container_tag="1.2.23",
     container_env={
         "USE_PVNET_GSP_SUM": "true",
         "LOGLEVEL": "DEBUG",
@@ -40,24 +41,58 @@ metrics_calculator = ContainerDefinition(
     container_memory=512,
 )
 
+# Original Metrics DAG (unchanged except for env vars)
 @dag(
     dag_id="uk-analysis-metrics",
-    description=__doc__,
-    schedule="0 21 * * *",
+    description="DAG to calculate metrics from the forecast.",
+    schedule="0 21 * * *",  # 21:00 UTC
     start_date=dt.datetime(2025, 3, 1, tzinfo=dt.UTC),
     catchup=False,
     default_args=default_args,
 )
 def metrics_dag() -> None:
-    """Dag to calculate metrics for the day before's forecasts."""
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-metrics",
         container_def=metrics_calculator,
-        on_failure_callback=slack_message_callback(
+        container_env={
+            "USE_PVNET_GSP_SUM": "true",
+            "RUN_METRICS": "true",  # Explicitly enable metrics
+            "RUN_ME": "false",      # Disable ME calculations
+            "LOGLEVEL": "DEBUG",
+        },
+        on_failure_callback=slack_message_callback( 
             "⚠️ The task {{ ti.task_id }} failed,"
             " but its ok. This task is not critical for live services. "
             "No out of hours support is required.",
         ),
     )
 
+# New ME Calculations DAG
+@dag(
+    dag_id="uk-analysis-me",
+    description="DAG to run ME calculations for the adjuster.",
+    schedule="0 20 * * *",  # 20:00 UTC (1 hour earlier)
+    start_date=dt.datetime(2025, 3, 1, tzinfo=dt.UTC),
+    catchup=False,
+    default_args=default_args,
+)
+def me_dag() -> None:
+    EcsAutoRegisterRunTaskOperator(
+        airflow_task_id="calculate-me",
+        container_def=metrics_calculator,
+        container_env={
+            "USE_PVNET_GSP_SUM": "true",
+            "RUN_METRICS": "false",  # Disable metrics
+            "RUN_ME": "true",       # Enable ME calculations
+            "LOGLEVEL": "DEBUG",
+        },
+        on_failure_callback=slack_message_callback(  
+            "⚠️ The task {{ ti.task_id }} failed,"
+            " but its ok. This task is not critical for live services. "
+            "No out of hours support is required.",
+        ),
+    )
+
+# Register both DAGs
 metrics_dag()
+me_dag()

--- a/src/airflow_dags/dags/uk/metrics-dag.py
+++ b/src/airflow_dags/dags/uk/metrics-dag.py
@@ -54,7 +54,7 @@ def metrics_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-metrics",
         container_def=metrics_calculator,
-        container_env={
+        env_overrides={
             "USE_PVNET_GSP_SUM": "true",
             "RUN_METRICS": "true",  # Explicitly enable metrics
             "RUN_ME": "false",  # Disable ME calculations
@@ -82,7 +82,7 @@ def me_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-me",
         container_def=metrics_calculator,
-        container_env={
+        env_overrides={
             "USE_PVNET_GSP_SUM": "true",
             "RUN_METRICS": "false",  # Disable metrics
             "RUN_ME": "true",  # Enable ME calculations

--- a/src/airflow_dags/dags/uk/metrics-dag.py
+++ b/src/airflow_dags/dags/uk/metrics-dag.py
@@ -50,7 +50,7 @@ metrics_calculator = ContainerDefinition(
     default_args=default_args,
 )
 def metrics_dag() -> None:
-    """Run the metrics DAG"""
+    """Run the metrics DAG."""
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-metrics",
         container_def=metrics_calculator,
@@ -78,7 +78,7 @@ def metrics_dag() -> None:
     default_args=default_args,
 )
 def me_dag() -> None:
-    """Run the ME DAG, used by the adjuster"""
+    """Run the ME DAG, used by the adjuster."""
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="calculate-me",
         container_def=metrics_calculator,

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -16,7 +16,7 @@ class TestImport(unittest.TestCase):
             include_examples=False,
             dag_folder=str(files("airflow_dags").joinpath("dags")),
         )
-        self.assertEqual(len(dag_bag.dags), 21)
+        self.assertEqual(len(dag_bag.dags), 22)
         self.assertFalse(dag_bag.import_errors)
 
         # Additional project-specific checks can be added here, e.g. to enforce each DAG has a tag


### PR DESCRIPTION
* Split metrics DAG into two; bump container to 1.2.23

Fixes #113 

## How Has This Been Tested?
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
