### PR TITLE
chore(forecast-gsp): Bump blend 1.0.8 -> 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ and handles the deployment process.
 
 ## Releases
 
+### 1.2.0
+
+- Cloudcasting inputs on the intraday forecaster in dev
+- Update forecast_blend `1.0.8` -> `1.1.1`
+- Update metrics `1.2.22` -> `1.2.23`
+- Add DAG to calculate ME
+
 ### 1.1.0
 
 - Update PVLive consumer to use on prem server - from `1.2.5` to `1.2.6`. 

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -93,7 +93,7 @@ national_forecaster = ContainerDefinition(
 forecast_blender = ContainerDefinition(
     name="forecast-blend",
     container_image="docker.io/openclimatefix/uk_pv_forecast_blend",
-    container_tag="1.1.1" if env == "development" else "1.0.8",
+    container_tag="1.1.1",
     container_env={"LOGLEVEL": "INFO"},
     container_secret_env={
         f"{env}/rds/forecast/": ["DB_URL"],


### PR DESCRIPTION
Updates the blend for both environments.