### PR TITLE
Update slack message links

### DIFF
--- a/src/airflow_dags/dags/india/consume-sat-dag.py
+++ b/src/airflow_dags/dags/india/consume-sat-dag.py
@@ -63,9 +63,10 @@ def sat_consumer_dag() -> None:
         max_active_tis_per_dag=10,
         on_failure_callback=slack_message_callback(
             "⚠️ The task {{ ti.task_id }} failed. "
-            "EUMETSAT status links are <https://uns.eumetsat.int/uns/|here> "
-            "and <https://masif.eumetsat.int/ossi/webpages/level2.html?"
-            "ossi_level2_filename=seviri_iodc.html|here>. "
+            "the EUMETSAT status link for the IODC satellite is "
+            "here <https://masif.eumetsat.int/ossi/webpages/level2.html?"
+            "ossi_level2_filename=seviri_iodc.html|here> "
+            "and the general EUMETSAT status link is <https://uns.eumetsat.int/uns/|here>. "
             "No out-of-hours support is required at the moment. "
             "Please see run book for appropriate actions.",
         ),

--- a/src/airflow_dags/dags/uk/consume-sat-dag.py
+++ b/src/airflow_dags/dags/uk/consume-sat-dag.py
@@ -106,9 +106,12 @@ def sat_consumer_dag() -> None:
             "⚠️ The task {{ ti.task_id }} failed. "
             "But it's OK, the forecast will automatically move over to PVNET-ECMWF, "
             "which doesn't need satellite data. "
-            "EUMETSAT status links are <https://uns.eumetsat.int/uns/|here> "
-            "and <https://masif.eumetsat.int/ossi/webpages/level3.html?ossi_level3_filename"
-            "=seviri_rss_hr.html&ossi_level2_filename=seviri_rss.html|here>. "
+            "EUMETSAT status link for the RSS service (5 min) is "
+            "<https://masif.eumetsat.int/ossi/webpages/level3.html?ossi_level3_filename"
+            "=seviri_rss_hr.json.html&ossi_level2_filename=seviri_rss.html|here>. "
+            "and the 0 degree (15 minute) which we use as a backup is "
+            "<https://masif.eumetsat.int/ossi/webpages/level3.html?ossi_level3_filename"
+            "=seviri_0deg_hr.json.html&ossi_level2_filename=seviri_0deg.html|here>. "
             "No out-of-hours support is required, but please log in an incident log.",
         ),
         max_active_tis_per_dag=10,


### PR DESCRIPTION
# Pull Request

Updating the slack messages that get sent when there are satellite consumer failures:
- Fixed the link for the uk satellite consumer which wasn't loading 
- Removed the generic EUMETSAT status link in the uk slack message and added the specific link to the 15 minute satellite to go with the 5 minute satellite link
- Switched the order of links in the IODC satellite consumer so the more specific status link is first 
