### PR TITLE
option for pvlive for development and prod

### DIFF
--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -37,7 +37,9 @@ pvlive_consumer = ContainerDefinition(
     container_tag="1.3.0" if env == "development" else "1.2.6",
     container_env={
         "LOGLEVEL": "DEBUG",
-        "PVLIVE_DOMAIN_URL": "api.pvlive.uk" if env == "development" else "api.solar.sheffield.ac.uk",
+        "PVLIVE_DOMAIN_URL": "api.pvlive.uk"
+        if env == "development"
+        else "api.solar.sheffield.ac.uk",
         # api.pvlive.uk" is the new one, api.solar.sheffield.ac.uk is the old one
     },
     container_secret_env={
@@ -47,6 +49,7 @@ pvlive_consumer = ContainerDefinition(
     container_cpu=256,
     container_memory=512,
 )
+
 
 @dag(
     dag_id="uk-consume-pvlive-intraday",
@@ -80,6 +83,7 @@ def pvlive_intraday_consumer_dag() -> None:
     )
 
     consume_pvlive_gsps >> update_api_last_gsp_data
+
 
 @dag(
     dag_id="uk-consume-pvlive-dayafter",
@@ -120,6 +124,6 @@ def pvlive_dayafter_consumer_dag() -> None:
 
     consume_pvlive_national >> consume_pvlive_gsps
 
+
 pvlive_intraday_consumer_dag()
 pvlive_dayafter_consumer_dag()
-

--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -65,7 +65,7 @@ def pvlive_intraday_consumer_dag() -> None:
         airflow_task_id="pvlive-intraday-consumer-gsps",
         container_def=pvlive_consumer,
         env_overrides={
-            "N_GSPS": "342",
+            "N_GSPS": "342" if env == "development" else "317",
             "REGIME": "in-day",
         },
         on_failure_callback=slack_message_callback(
@@ -116,7 +116,7 @@ def pvlive_dayafter_consumer_dag() -> None:
         airflow_task_id="consume-pvlive-dayafter-gsps",
         container_def=pvlive_consumer,
         env_overrides={
-            "N_GSPS": "342",
+            "N_GSPS": "342" if env == "development" else "317",
             "REGIME": "day-after",
         },
         on_failure_callback=slack_message_callback(error_message),

--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -34,10 +34,10 @@ default_args = {
 pvlive_consumer = ContainerDefinition(
     name="pvlive-consumer",
     container_image="docker.io/openclimatefix/pvliveconsumer",
-    container_tag="1.3.0",
+    container_tag="1.3.0" if env == "development" else "1.2.6",
     container_env={
         "LOGLEVEL": "DEBUG",
-        "PVLIVE_DOMAIN_URL": "api.pvlive.uk",
+        "PVLIVE_DOMAIN_URL": "api.pvlive.uk" if env == "development" else "api.solar.sheffield.ac.uk",
         # api.pvlive.uk" is the new one, api.solar.sheffield.ac.uk is the old one
     },
     container_secret_env={


### PR DESCRIPTION
# Pull Request

## Description

split development and production for pvlive consumer. 
On development use
- version = 1.3.0
- domain_url = "api.pvlive.uk"

on production
- version = 1.2.6
- domain_url = "api.solar.sheffield.ac.uk"

## How Has This Been Tested?

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
