### PR TITLE
and old and new PVLive consumers

### DIFF
--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -92,7 +92,7 @@ def pvlive_intraday_consumer_dag() -> None:
 
     # we do want to remove this
     consume_pvlive_gsps_old = EcsAutoRegisterRunTaskOperator(
-        airflow_task_id="pvlive-intraday-consumer-gsps",
+        airflow_task_id="pvlive-intraday-consumer-gsps-old",
         container_def=pvlive_consumer_old,
         env_overrides={
             "N_GSPS": "317",
@@ -152,7 +152,7 @@ def pvlive_dayafter_consumer_dag() -> None:
     )
 
     consume_pvlive_gsps_old = EcsAutoRegisterRunTaskOperator(
-        airflow_task_id="consume-pvlive-dayafter-gsps",
+        airflow_task_id="consume-pvlive-dayafter-gsps-old",
         container_def=pvlive_consumer_old,
         env_overrides={
             "N_GSPS": "317",

--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -37,7 +37,7 @@ pvlive_consumer_old = ContainerDefinition(
     container_tag="1.2.6",
     container_env={
         "LOGLEVEL": "DEBUG",
-        "PVLIVE_DOMAIN_URL": "api.solar.sheffield.ac.uk"
+        "PVLIVE_DOMAIN_URL": "api.solar.sheffield.ac.uk",
     },
     container_secret_env={
         f"{env}/rds/forecast/": ["DB_URL"],
@@ -53,7 +53,7 @@ pvlive_consumer = ContainerDefinition(
     container_tag="1.3.0",
     container_env={
         "LOGLEVEL": "DEBUG",
-        "PVLIVE_DOMAIN_URL": "api.pvlive.uk"
+        "PVLIVE_DOMAIN_URL": "api.pvlive.uk",
     },
     container_secret_env={
         f"{env}/rds/forecast/": ["DB_URL"],

--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -112,7 +112,7 @@ def pvlive_intraday_consumer_dag() -> None:
         bash_command=f"curl -X GET {url}/v0/solar/GB/update_last_data?component=gsp",
     )
 
-    consume_pvlive_gsps_old >> update_api_last_gsp_data >> consume_pvlive_gsps
+    consume_pvlive_gsps >> update_api_last_gsp_data >> consume_pvlive_gsps_old
 
 @dag(
     dag_id="uk-consume-pvlive-dayafter",
@@ -161,7 +161,7 @@ def pvlive_dayafter_consumer_dag() -> None:
         on_failure_callback=slack_message_callback(error_message),
     )
 
-    consume_pvlive_national >> consume_pvlive_gsps_old >> consume_pvlive_gsps
+    consume_pvlive_national >> consume_pvlive_gsps >> consume_pvlive_gsps_old
 
 
 pvlive_intraday_consumer_dag()


### PR DESCRIPTION
# Pull Request

## Description

Add old and new PVLive consumers to run at the same time, 
This means it can run on dev and production, and have all old gsp and the news ones. This measne PVnet will work on dev + we can add new models that work on new gsps

downside is, pvnet old will do some of the work that pvlive new will do, so we dont fully test that pvlive is working. But when we are happy with changes in other moduels, we can change this

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
