### PR TITLE
pin gsp intraday to "2.5.18" on production

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -54,7 +54,7 @@ gsp_forecaster = ContainerDefinition(
 dev_gsp_intraday_forecaster = ContainerDefinition(
     name="forecast-pvnet",
     container_image="ghcr.io/openclimatefix/uk-pvnet-app",
-    container_tag="cloudcasting_inputs",
+    container_tag="cloudcasting_inputs" if env == "development" else "2.5.18",
     container_env={
         "LOGLEVEL": "INFO",
         "RAISE_MODEL_FAILURE": "critical",


### PR DESCRIPTION
# Pull Request

## Description

Fix gsp intraday on production to 2.5.18 not cloudcasting

Fixes #

## How Has This Been Tested?

Ci tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
