### PR TITLE
Change branch for development GSP intraday forecaster image

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -55,7 +55,7 @@ gsp_forecaster = ContainerDefinition(
 dev_gsp_intraday_forecaster = ContainerDefinition(
     name="forecast-pvnet",
     container_image="ghcr.io/openclimatefix/uk-pvnet-app",
-    container_tag="cloudcasting_inputs" if env == "development" else "2.5.18",
+    container_tag="dev" if env == "development" else "2.5.18",
     container_env={
         "LOGLEVEL": "INFO",
         "RAISE_MODEL_FAILURE": "critical",


### PR DESCRIPTION
In uk-pvnet-app we are changing to work on the `dev` branch rather than the `cloudcasting_inputs` branch. This PR means we will run the image created from the new branch