### PR TITLE
add new forecast site model

### DIFF
--- a/src/airflow_dags/dags/india/forecast-site-dag.py
+++ b/src/airflow_dags/dags/india/forecast-site-dag.py
@@ -42,6 +42,26 @@ india_forecaster = ContainerDefinition(
     domain="india",
 )
 
+ad_forecaster = ContainerDefinition(
+    name="forecast-ad",
+    container_image="ghcr.io/openclimatefix/site-forecast-app",
+    container_tag="ad-model",
+    container_env={
+        "NWP_MO_GLOBAL_ZARR_PATH": f"s3://india-nwp-{env}/metoffice/data/latest.zarr",
+        "NWP_ECMWF_ZARR_PATH": f"s3://india-nwp-{env}/ecmwf/data/latest.zarr",
+        "SATELLITE_ZARR_PATH": f"s3://india-satellite-{env}/data/latest/iodc_latest.zarr.zip",
+        "CLIENT_NAME": "ad",
+        "COUNTRY": "india",
+    },
+    container_secret_env={
+        f"{env}/rds/indiadb": ["DB_URL"],
+        f"{env}/huggingface/token": ["HUGGINGFACE_TOKEN"],
+    },
+    container_cpu=1024,
+    container_memory=3072,
+    domain="india",
+)
+
 # hour the forecast can run, not include 7,8,19,20
 hours = "0,1,2,3,4,5,6,9,10,11,12,13,14,15,16,17,18,21,22,23"
 @dag(
@@ -86,8 +106,8 @@ def ad_forecast_dag() -> None:
     """Create AD forecasts."""
     latest_only_op = LatestOnlyOperator(task_id="latest_only")
 
-    forecast_ad_op = EcsAutoRegisterRunTaskOperator(
-        airflow_task_id="forecast-ad",
+    forecast_ad_old_op = EcsAutoRegisterRunTaskOperator(
+        airflow_task_id="forecast-ad-old",
         container_def=india_forecaster,
         env_overrides={
             "CLIENT_NAME": "ad",
@@ -103,7 +123,18 @@ def ad_forecast_dag() -> None:
         max_active_tis_per_dag=10,
     )
 
-    latest_only_op >> forecast_ad_op
+    forecast_ad_op = EcsAutoRegisterRunTaskOperator(
+        airflow_task_id="forecast-ad",
+        container_def=ad_forecaster,
+        on_failure_callback=slack_message_callback(
+            "⚠️ The task {{ ti.task_id }} failed. "
+            "No out-of-hours support is required at the moment. "
+            "Please see run book for appropriate actions.",
+        ),
+        max_active_tis_per_dag=10,
+    )
+
+    latest_only_op >> [forecast_ad_op, forecast_ad_old_op]
 
 ruvnl_forecast_dag()
 ad_forecast_dag()

--- a/src/airflow_dags/dags/india/forecast-site-dag.py
+++ b/src/airflow_dags/dags/india/forecast-site-dag.py
@@ -45,7 +45,7 @@ india_forecaster = ContainerDefinition(
 ad_forecaster = ContainerDefinition(
     name="forecast-ad",
     container_image="ghcr.io/openclimatefix/site-forecast-app",
-    container_tag="ad-model",
+    container_tag="0.0.16",
     container_env={
         "NWP_MO_GLOBAL_ZARR_PATH": f"s3://india-nwp-{env}/metoffice/data/latest.zarr",
         "NWP_ECMWF_ZARR_PATH": f"s3://india-nwp-{env}/ecmwf/data/latest.zarr",


### PR DESCRIPTION
# Pull Request

## Description

Add new ad forecast api which runs PV, not still a bug, but want to get it out and running, to see if that helps understand what the problem is
We still need the old one, as it runs the old models for PV and wind

## How Has This Been Tested?

- [x] CI tests
- [x] put on dev

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
