### PR TITLE
fix: add trailing commas for Ruff lint compliance

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -178,7 +178,7 @@ def gsp_forecast_pvnet_dag() -> None:
         trigger_rule="one_failed",
         python_callable=check_forecast_status,
         on_success_callback=slack_message_callback(
-            "{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}"
+            "{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}",
         ),
         on_failure_callback=slack_message_callback(
             "⚠️ The task {{ ti.task_id }} failed. 🇬🇧"

--- a/src/airflow_dags/plugins/operators/ecs_run_task_operator.py
+++ b/src/airflow_dags/plugins/operators/ecs_run_task_operator.py
@@ -88,7 +88,7 @@ class EcsAutoRegisterRunTaskOperator(EcsRunTaskOperator):
                         )
                         return True
                 elif existing_container_def.get(
-                    key
+                    key,
                 ) != self.container_def.ecs_container_definition().get(key):
                     self.log.info(
                         f"Definition key '{key}' different, registering new task definition",

--- a/src/airflow_dags/plugins/scripts/s3.py
+++ b/src/airflow_dags/plugins/scripts/s3.py
@@ -17,7 +17,7 @@ def determine_latest_zarr(bucket: str, prefix: str) -> None:
     # Get a list of all the non-latest zarrs in the bucket prefix
     prefixes = s3hook.list_prefixes(bucket_name=bucket, prefix=prefix + "/", delimiter="/")
     zarrs = sorted(
-        [p for p in prefixes if p.endswith(".zarr/") and "latest" not in p], reverse=True
+        [p for p in prefixes if p.endswith(".zarr/") and "latest" not in p], reverse=True,
     )
     # Get the size of the most recent zarr and the latest.zarr zarr
     s3bucket = s3hook.get_bucket(bucket_name=bucket)


### PR DESCRIPTION
# Pull Request

## ✨ Fix: trailing commas for Ruff lint compliance

### Description

This PR fixes linting issues flagged by Ruff on the `flags` branch.  
Specifically, it adds the missing trailing commas in the following files:
- `forecast-gsp-dag.py`
- `ecs_run_task_operator.py`
- `s3.py`

These changes resolve the `COM812 Trailing comma missing` errors.

### Fixes

This helps resolve CI failures in the `flags` → `main` PR and keeps the codebase compliant with the OCF linting standards.

### How Has This Been Tested?

- [x] Ran `ruff check . --fix` locally  
- [x] Confirmed that no linting errors remain  
- [x] CI should now pass on `flags`

_No changes to data processing or functionality — purely a formatting fix._

---

## ✅ Checklist

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] I have checked my code and corrected any misspellings
