### PR TITLE
release 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ and handles the deployment process.
 
 ## Releases
 
+### 1.10.0 - 2025-07-17
+
+India
+- Database migration is needed
+- Add checks on API
+- RUVNL consumer to `1.2.0`, use new database schema. 
+- Site Forecast to `1.2.0`, use new database schema.
+ Site API needs to be `>=0.2.0`
+
+UK
+- Site Database migration is needed
+- Add checks on site API
+- PV Consumer to `1.2.1`, use new database schema.
+- PV Site Forecast to `1.1.0`, use new database schema.
+- Reset old ec2 instances for UK National API. 
+- Site API needs to be `>=1.1.0`
+
+NL
+- Database migration is needed (Same as UK Sites)
+- Ned NL consumer to `1.2.1`, use new database schema.
+- Forecast to `1.1.0`, use new database schema.
+
+
 ### 1.9.0 - 2025-07-10
 
 - Add country flags to slack messages

--- a/README.md
+++ b/README.md
@@ -30,15 +30,13 @@ India
 - Add checks on API
 - RUVNL consumer to `1.2.0`, use new database schema. 
 - Site Forecast to `1.2.0`, use new database schema.
- Site API needs to be `>=0.2.0`
 
 UK
 - Site Database migration is needed
 - Add checks on site API
 - PV Consumer to `1.2.1`, use new database schema.
 - PV Site Forecast to `1.1.0`, use new database schema.
-- Reset old ec2 instances for UK National API. 
-- Site API needs to be `>=1.1.0`
+- Reset old ec2 instances for UK National API.
 
 NL
 - Database migration is needed (Same as UK Sites)


### PR DESCRIPTION
# Pull Request

## Description

Release 1.10
Mainly for https://github.com/openclimatefix/pv-site-datamodel/issues/104

India
- Database migration is needed
- Add checks on API
- RUVNL consumer to `1.2.0`, use new database schema. 
- Site Forecast to `1.2.0`, use new database schema.
 Site API needs to be `>=0.2.0`

UK
- Site Database migration is needed
- Add checks on site API
- PV Consumer to `1.2.1`, use new database schema.
- PV Site Forecast to `1.1.0`, use new database schema.
- Reset old ec2 instances for UK National API. 
- Site API needs to be `>=1.1.0`

NL
- Database migration is needed (Same as UK Sites)
- Ned NL consumer to `1.2.1`, use new database schema.
- Forecast to `1.1.0`, use new database schema.


## How Has This Been Tested?

- CI tests
- ran on dev

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
