### PR TITLE
Remove old pvlive container as per #290

### DIFF
--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -31,21 +31,7 @@ default_args = {
     "max_active_tasks": 10,
 }
 
-pvlive_consumer_old = ContainerDefinition(
-    name="pvlive-consumer",
-    container_image="docker.io/openclimatefix/pvliveconsumer",
-    container_tag="1.2.6",
-    container_env={
-        "LOGLEVEL": "DEBUG",
-        "PVLIVE_DOMAIN_URL": "api.solar.sheffield.ac.uk",
-    },
-    container_secret_env={
-        f"{env}/rds/forecast/": ["DB_URL"],
-    },
-    domain="uk",
-    container_cpu=256,
-    container_memory=512,
-)
+# pvlive_consumer_old is deleted
 
 pvlive_consumer = ContainerDefinition(
     name="pvlive-consumer",


### PR DESCRIPTION
# Pull Request

## Description

deleting old pvlive_consumer


Fixes #
deleted pvlive_consumer_old

## How Has This Been Tested?

The term pvlive_consumer_old has been searched and found none other the definition.


