### PR TITLE
Feature: Default 12 hours of PVLive history for in-day consumer #292

### DIFF
--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -80,6 +80,8 @@ def pvlive_intraday_consumer_dag() -> None:
         env_overrides={
             "N_GSPS": "342",
             "REGIME": "in-day",
+            "BACKFILL_HOURS": "12",
+            
         },
         on_failure_callback=slack_message_callback(
             f"⚠️🇬🇧 The {get_task_link()} failed. "


### PR DESCRIPTION
# Pull Request

## Description


Previously, the BACKFILL_HOURS environment variable was not explicitly set in the Airflow DAG's task definition, causing the underlying pvlive-consumer application to default to 2 hours of history. By setting BACKFILL_HOURS to 12 within the env_overrides for the pvlive-intraday-consumer-gsps task, we align with the requirement to improve data gap filling.

This addresses issue #292.

Fixes #

## How Has This Been Tested?

As this change primarily involves modifying an Airflow DAG's environment variable passed to a container, direct local testing to simulate the full Airflow environment and container execution is not typically feasible for a first contribution.

However, the change is a simple configuration update:

I have verified the modification of the env_overrides dictionary in src/airflow_dags/dags/uk/consume-pvlive-dag.py to include "BACKFILL_HOURS": "12".

I have also verified that the os.getenv("BACKFILL_HOURS", 2) line in the external pvlive-consumer code will correctly pick up this new environment variable value.

Testing would ideally be performed within the OCF Airflow deployment environment to confirm the container receives the new environment variable and performs the backfill as expected.