### PR TITLE
Update consume-sat-dag.py

### DIFF
--- a/src/airflow_dags/dags/uk/consume-sat-dag.py
+++ b/src/airflow_dags/dags/uk/consume-sat-dag.py
@@ -140,7 +140,7 @@ def sat_consumer_dag() -> None:
     )
     extract_latest_rss_op = extract_latest_zarr(
         bucket=f"nowcasting-sat-{env}",
-        prefix="testdata/rss/data/rss_3000m.icechunk",
+        prefix="testdata/rss/data/rss_uk3000m.icechunk",
         window_mins=210,
         cadence_mins=5,
     )


### PR DESCRIPTION
# Pull Request

## Description

Make sure we extract the correct file for the satellite icechunk 

## How Has This Been Tested?

- looked at s3, and see the latest file its saving to is [rss_uk3000m.icechunk/](https://eu-west-1.console.aws.amazon.com/s3/buckets/nowcasting-sat-development?region=eu-west-1&bucketType=general&prefix=testdata/rss/data/rss_uk3000m.icechunk/&showversions=false). This might be a recernt change in the satellite consumer

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
