### PR TITLE
Uk-site-forecast to INFO log level

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-site-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-site-dag.py
@@ -30,7 +30,7 @@ site_forecaster = ContainerDefinition(
     container_image="docker.io/openclimatefix/pvsite_forecast",
     container_tag="1.1.0",
     container_env={
-        "LOGLEVEL": "DEBUG",
+        "LOGLEVEL": "INFO",
         "NWP_ZARR_PATH": f"s3://nowcasting-nwp-{env}/data-metoffice/latest.zarr",
         "OCF_ENVIRONMENT": env,
     },


### PR DESCRIPTION
# Pull Request

## Description

Change uk-foreacs-site to INFO log level (from debug)
Helps with https://github.com/openclimatefix/ocf-infrastructure/issues/893

## How Has This Been Tested?

CI tests

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
