### PR TITLE
Update warning and error messages to include PVNet DA checks

### DIFF
--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -107,47 +107,56 @@ def check_forecast_status() -> str:
 
     pvnet_last_run = get_forecast_last_run_from_api("pvnet_v2")
     pvnet_ecmwf_last_run = get_forecast_last_run_from_api("pvnet_ecmwf")
+    pvnet_da_last_run = get_forecast_last_run_from_api("pvnet_da")
 
     pvnet_delay = now - pvnet_last_run
     pvnet_ecmwf_delay = now - pvnet_ecmwf_last_run
+    pvnet_da_delay = now - pvnet_da_last_run
 
     pvnet_last_run_str = pvnet_last_run.strftime("%Y-%m-%d %H:%M")
     pvnet_ecmwf_last_run_str = pvnet_ecmwf_last_run.strftime("%Y-%m-%d %H:%M")
+    pvnet_da_last_run_str = pvnet_da_last_run.strftime("%Y-%m-%d %H:%M")
 
     hours = 2
-
-    if (pvnet_delay <= dt.timedelta(hours=hours)) and (
-        pvnet_ecmwf_delay <= dt.timedelta(hours=hours)
+    
+    #all models ran recently
+    if (
+        pvnet_delay <= dt.timedelta(hours=hours)
+        and pvnet_ecmwf_delay <= dt.timedelta(hours=hours)
+        and pvnet_da_delay <= dt.timedelta(hours=hours)
     ):
         message = (
             f"⚠️🇬🇧 The {get_task_link()} has failed, "
-            f"but PVNet and PVNet ECMWF only model have run within the last {hours} hours. "
+            f"but PVNet, PVNet ECMWF-only, and PVNet DA have run within the last {hours} hours. "
             "No actions is required. "
         )
-
-    elif (pvnet_delay > dt.timedelta(hours=hours)) and (
-        pvnet_ecmwf_delay <= dt.timedelta(hours=hours)
-    ):
+    
+    #PVNet late, but PVNet DA ran
+    elif pvnet_delay > dt.timedelta(hours=hours) and pvnet_da_delay <= dt.timedelta(hours=hours):
         message = (
             f"⚠️🇬🇧 The {get_task_link()} failed. "
             f"This means in the last {hours} hours, PVNet has failed to run "
-            "but PVNet ECMWF only model has run. "
+            "but PVNet DA model has run. "
             "Please see run book for appropriate actions."
         )
-    elif (pvnet_delay > dt.timedelta(hours=hours)) and (
-        pvnet_ecmwf_delay > dt.timedelta(hours=hours)
-    ):
+
+    #PVNet + PVNet DA both late
+    elif pvnet_delay > dt.timedelta(hours=hours) and pvnet_da_delay > dt.timedelta(hours=hours):
         message = (
             f"❌🇬🇧 The {get_task_link()} failed. "
-            f"This means PVNet and PVNET_ECMWF has failed to run in the last {hours} hours. "
+            f"This means PVNet and PVNET_DA has failed to run in the last {hours} hours. "
             f" Last success run of PVNet was {pvnet_last_run_str} "
+            f"and PVNet DA was {pvnet_da_last_run_str}. "
             f"and PVNet ECMWF was {pvnet_ecmwf_last_run_str}. "
             "Please see run book for appropriate actions."
         )
+
+    #fallback (catch-all)
     else:
         message = (
             f"❌🇬🇧 The {get_task_link()} failed. "
             f" Last success run of PVNet was {pvnet_last_run_str} "
+            f"and PVNet DA was {pvnet_da_last_run_str}. "
             f"and PVNet ECMWF was {pvnet_ecmwf_last_run_str}. "
             "Please see run book for appropriate actions."
         )


### PR DESCRIPTION
# Pull Request

## Description

This PR updates the warning and error messages in forecast-gsp-dag.py to include the new pvnet_da model, alongside pvnet and pvnet_ecmwf.

Fixes #358 

## How Has This Been Tested?

Ran unit tests locally (python -m unittest discover -s tests -p "test_*.py").

Verified that f-strings return expected messages depending on run conditions.

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
