### PR TITLE
Add slack alert channel split

### DIFF
--- a/src/airflow_dags/dags/india/check-api.py
+++ b/src/airflow_dags/dags/india/check-api.py
@@ -7,7 +7,7 @@ import os
 from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 
-from airflow_dags.plugins.callbacks.slack import slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.scripts.api_checks import (
     call_api,
     check_key_in_data,
@@ -156,10 +156,13 @@ def api_site_check() -> None:
         task_id="api-uk-national-gsp-check-if-any-task-failed",
         python_callable=lambda: None,
         trigger_rule="one_failed",
-        on_success_callback=slack_message_callback(
-            "⚠️🇮🇳 One of the API checks has failed. "
-            "See which ones have failed on airflow, to help debug the issue. "
-            "No out-of-hours support is required.",
+        on_success_callback=get_slack_message_callback(
+            country="in",
+            additional_message_context=(
+                "One of the API checks has failed. "
+                "See which ones have failed on airflow, to help debug the issue. "
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/india/consume-nwp-dag.py
+++ b/src/airflow_dags/dags/india/consume-nwp-dag.py
@@ -6,7 +6,7 @@ import os
 from airflow.decorators import dag
 from airflow.operators.latest_only import LatestOnlyOperator
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -80,12 +80,13 @@ def nwp_consumer_dag() -> None:
             "ZARRDIR": f"s3://india-nwp-{env}/ecmwf/data",
         },
         max_active_tis_per_dag=10,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇮🇳 The {get_task_link()} failed. "
-            "The forecast will continue running until it runs out of data. "
-            "ECMWF status link is <https://status.ecmwf.int/|here>. "
-            "No out-of-hours support is required at the moment. "
-            "Please see run book for appropriate actions.",
+        on_failure_callback=get_slack_message_callback(
+            country="in",
+            additional_message_context=(
+                "The forecast will continue running until it runs out of data. "
+                "ECMWF status link is <https://status.ecmwf.int/|here>. "
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 
@@ -99,13 +100,14 @@ def nwp_consumer_dag() -> None:
             # SDE has nans
             "ALLOWED_VALIDATION_FAILURE_PERCENTAGE": "0.07",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇮🇳 The {get_task_link()} failed."
-            "The forecast will continue running until it runs out of data. "
-            "GFS status link is "
-            "<https://www.nco.ncep.noaa.gov/pmb/nwprod/prodstat/|here>. "
-            "No out-of-hours support is required at the moment. "
-            "Please see run book for appropriate actions.",
+        on_failure_callback=get_slack_message_callback(
+            country="in",
+            additional_message_context=(
+                "The forecast will continue running until it runs out of data. "
+                "GFS status link is "
+                "<https://www.nco.ncep.noaa.gov/pmb/nwprod/prodstat/|here>. "
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 
@@ -118,13 +120,14 @@ def nwp_consumer_dag() -> None:
             "METOFFICE_ORDER_ID": "india-11params-54steps",
             "ZARRDIR": f"s3://india-nwp-{env}/metoffice/data",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇮🇳 The {get_task_link()} failed. "
-            "The forecast will continue running until it runs out of data. "
-            "Metoffice status link is "
-            "<https://datahub.metoffice.gov.uk/support/service-status|here>. "
-            "No out-of-hours support is required at the moment. "
-            "Please see run book for appropriate actions.",
+        on_failure_callback=get_slack_message_callback(
+            country="in",
+            additional_message_context=(
+                "The forecast will continue running until it runs out of data. "
+                "Metoffice status link is "
+                "<https://datahub.metoffice.gov.uk/support/service-status|here>. "
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/india/consume-sat-dag.py
+++ b/src/airflow_dags/dags/india/consume-sat-dag.py
@@ -87,9 +87,9 @@ def sat_consumer_dag() -> None:
                 "The EUMETSAT status link for the IODC satellite is "
                 "<https://masif.eumetsat.int/ossi/webpages/level2.html?"
                 "ossi_level2_filename=seviri_iodc.html|here> "
-                "and the general EUMETSAT status link is <https://uns.eumetsat.int/uns/|here>."
+                "and the general EUMETSAT status link is <https://uns.eumetsat.int/uns/|here>. "
             ),
-            urgency=Urgency.NON_CRITICAL,
+            urgency=Urgency.SUBCRITICAL,
         ),
 
     )

--- a/src/airflow_dags/dags/india/forecast-site-dag.py
+++ b/src/airflow_dags/dags/india/forecast-site-dag.py
@@ -86,9 +86,9 @@ def ruvnl_forecast_dag() -> None:
         on_failure_callback=get_slack_message_callback(
             country="in",
             additional_message_context=(
-                "This would ideally be fixed before for DA actions at 09.00 IST."
+                "This would ideally be fixed before for DA actions at 09.00 IST. "
             ),
-            urgency=Urgency.NON_CRITICAL,
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 
@@ -117,7 +117,7 @@ def ad_forecast_dag() -> None:
             "SATELLITE_ZARR_PATH": f"s3://india-satellite-{env}/iodc/data/latest.zarr.zip",
             "SAVE_BATCHES_DIR": f"s3://india-forecast-{env}/ad",
         },
-        on_failure_callback=get_slack_message_callback(country="in", urgency=Urgency.NON_CRITICAL),
+        on_failure_callback=get_slack_message_callback(country="in", urgency=Urgency.SUBCRITICAL),
         max_active_tis_per_dag=10,
     )
 
@@ -129,7 +129,7 @@ def ad_forecast_dag() -> None:
         },
         on_failure_callback=get_slack_message_callback(
             country="in",
-            urgency=Urgency.NON_CRITICAL,
+            urgency=Urgency.SUBCRITICAL,
         ),
         max_active_tis_per_dag=10,
     )

--- a/src/airflow_dags/dags/uk/check-api-national-gsp.py
+++ b/src/airflow_dags/dags/uk/check-api-national-gsp.py
@@ -7,7 +7,7 @@ import os
 from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 
-from airflow_dags.plugins.callbacks.slack import slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.scripts.api_checks import (
     call_api,
     check_key_in_data,
@@ -523,10 +523,12 @@ def api_national_gsp_check() -> None:
         task_id="api-uk-national-gsp-check-if-any-task-failed",
         python_callable=lambda: None,
         trigger_rule="one_failed",
-        on_success_callback=slack_message_callback(
-            "⚠️ One of the API checks has failed. 🇬🇧 "
+        on_success_callback=get_slack_message_callback(
+            additional_message_context= (
+            "One of the API checks has failed. "
             "See which ones have failed on airflow, to help debug the issue. "
-            "No out-of-hours support is required.",
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/check-api-site.py
+++ b/src/airflow_dags/dags/uk/check-api-site.py
@@ -7,7 +7,10 @@ import os
 from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 
-from airflow_dags.plugins.callbacks.slack import slack_message_callback
+from airflow_dags.plugins.callbacks.slack import (
+    Urgency,
+    get_slack_message_callback,
+)
 from airflow_dags.plugins.scripts.api_checks import (
     call_api,
     check_key_in_data,
@@ -126,10 +129,12 @@ def api_site_check() -> None:
         task_id="api-uk-national-gsp-check-if-any-task-failed",
         python_callable=lambda: None,
         trigger_rule="one_failed",
-        on_success_callback=slack_message_callback(
-            "⚠️ 🇬🇧 {{ ti.dag_id }} One of the API Site checks has failed. "
+        on_success_callback=get_slack_message_callback(
+            additional_message_context= (
+            "One of the API Site checks has failed. "
             "See which ones have failed on airflow, to help debug the issue. "
-            "No out-of-hours support is required.",
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/cloudcasting-dags.py
+++ b/src/airflow_dags/dags/uk/cloudcasting-dags.py
@@ -11,8 +11,6 @@ from airflow.decorators import dag
 from airflow_dags.plugins.callbacks.slack import (
     Urgency,
     get_slack_message_callback,
-    get_task_link,
-    slack_message_callback,
 )
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
@@ -63,7 +61,7 @@ def cloudcasting_inference_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="run-cloudcasting-inference",
         container_def=cloudcasting_inference,
-        on_failure_callback=get_slack_message_callback(urgency=Urgency.NON_CRITICAL),
+        on_failure_callback=get_slack_message_callback(urgency=Urgency.SUBCRITICAL),
     )
 
 
@@ -96,9 +94,7 @@ def cloudcasting_metrics_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="run-cloudcasting-metrics",
         container_def=cloudcasting_metrics,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed. This does not require out of hours support.",
-        ),
+        on_failure_callback=get_slack_message_callback(urgency=Urgency.SUBCRITICAL),
     )
 
 

--- a/src/airflow_dags/dags/uk/consume-ned-nl-dag.py
+++ b/src/airflow_dags/dags/uk/consume-ned-nl-dag.py
@@ -5,7 +5,7 @@ import os
 
 from airflow.decorators import dag
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -57,10 +57,10 @@ def ned_nl_consumer_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="nl-consume-ned-nl-generation",
         container_def=ned_nl_consumer,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇳🇱 The {get_task_link()} failed."
-            "But its ok, this only used for comparison. "
-            "No out of office hours support is required.",
+        on_failure_callback=get_slack_message_callback(
+            country="nl",
+            additional_message_context="But its ok, this only used for comparison. ",
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 
@@ -78,10 +78,10 @@ def ned_nl_forecast_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="nl-forecast-ned-nl",
         container_def=ned_nl_consumer,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇳🇱 The {get_task_link()} failed. "
-            "But its ok, this only used for comparison. "
-            "No out of office hours support is required.",
+        on_failure_callback=get_slack_message_callback(
+            country="nl",
+            additional_message_context="But its ok, this only used for comparison. ",
+            urgency=Urgency.SUBCRITICAL,
         ),
         env_overrides={
             "HISTORIC_OR_FORECAST": "forecast",

--- a/src/airflow_dags/dags/uk/consume-neso-dag.py
+++ b/src/airflow_dags/dags/uk/consume-neso-dag.py
@@ -5,7 +5,7 @@ import os
 
 from airflow.decorators import dag
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -53,10 +53,9 @@ def neso_consumer_dag() -> None:
     EcsAutoRegisterRunTaskOperator(
         airflow_task_id="consume-neso-forecast",
         container_def=neso_consumer,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed."
-            "But its ok, this only used for comparison. "
-            "No out of office hours support is required.",
+        on_failure_callback=get_slack_message_callback(
+            additional_message_context="But its ok, this only used for comparison. ",
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/consume-nwp-dag.py
+++ b/src/airflow_dags/dags/uk/consume-nwp-dag.py
@@ -7,7 +7,7 @@ from airflow.decorators import dag
 from airflow.operators.bash import BashOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -82,13 +82,13 @@ def nwp_consumer_dag() -> None:
             "METOFFICE_ORDER_ID": "uk-12params-42steps",
             "ZARRDIR": f"s3://nowcasting-nwp-{env}/data-metoffice",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed. "
+        on_failure_callback=get_slack_message_callback(
+            additional_message_context= (
             "This is non-critical; the forecast will move to ECMWF-only, "
             "Metoffice status link is "
             "<https://datahub.metoffice.gov.uk/support/service-status|here> "
-            "No out of office hours support is required, "
-            "but please log in an incident log. ",
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 
@@ -102,11 +102,11 @@ def nwp_consumer_dag() -> None:
             "ECMWF_REALTIME_S3_REGION": "eu-west-1",
             "ZARRDIR": f"s3://nowcasting-nwp-{env}/ecmwf/data",
         },
-        on_failure_callback=slack_message_callback(
-            f"❌🇬🇧 The {get_task_link()} failed.  "
+        on_failure_callback=get_slack_message_callback(
+            additional_message_context= (
             "The forecast will continue running until it runs out of data. "
             "ECMWF status link is <https://status.ecmwf.int/|here> "
-            "Please see run book for appropriate actions. ",
+            ),
         ),
     )
 

--- a/src/airflow_dags/dags/uk/consume-nwp-nl-dag.py
+++ b/src/airflow_dags/dags/uk/consume-nwp-nl-dag.py
@@ -7,7 +7,7 @@ from airflow.decorators import dag
 from airflow.operators.bash import BashOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -82,11 +82,12 @@ def nl_nwp_consumer_dag() -> None:
             "ECMWF_REALTIME_S3_REGION": "eu-west-1",
             "ZARRDIR": f"s3://nowcasting-nwp-{env}/ecmwf-nl/data",
         },
-        on_failure_callback=slack_message_callback(
-            f"❌🇳🇱 The {get_task_link()} failed.  "
+        on_failure_callback=get_slack_message_callback(
+            country="nl",
+            additional_message_context= (
             "The forecast will continue running until it runs out of data. "
             "ECMWF status link is <https://status.ecmwf.int/|here> "
-            "Please see run book for appropriate actions. ",
+            ),
         ),
     )
 

--- a/src/airflow_dags/dags/uk/consume-pv-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pv-dag.py
@@ -63,7 +63,7 @@ def pv_consumer_dag() -> None:
         max_active_tis_per_dag=10,
         on_failure_callback=get_slack_message_callback(
             additional_message_context="This isn't needed for any production services. ",
-            urgency=Urgency.SUBCRITICAL
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/consume-pv-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pv-dag.py
@@ -6,7 +6,7 @@ import os
 from airflow.decorators import dag
 from airflow.operators.latest_only import LatestOnlyOperator
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -61,10 +61,9 @@ def pv_consumer_dag() -> None:
         airflow_task_id="consume-passiv-pv-data",
         container_def=pv_consumer,
         max_active_tis_per_dag=10,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed. "
-            "But its ok, this isnt needed for any production services. "
-            "No out of office hours support is required.",
+        on_failure_callback=get_slack_message_callback(
+            additional_message_context="This isn't needed for any production services. ",
+            urgency=Urgency.SUBCRITICAL
         ),
     )
 

--- a/src/airflow_dags/dags/uk/consume-pvlive-dag.py
+++ b/src/airflow_dags/dags/uk/consume-pvlive-dag.py
@@ -94,7 +94,6 @@ def pvlive_intraday_consumer_dag() -> None:
 )
 def pvlive_dayafter_consumer_dag() -> None:
     """Dag to download pvlive-dayafter data."""
-
     consume_pvlive_national = EcsAutoRegisterRunTaskOperator(
         airflow_task_id="consume-pvlive-dayafter-national",
         container_def=pvlive_consumer,

--- a/src/airflow_dags/dags/uk/consume-sat-dag.py
+++ b/src/airflow_dags/dags/uk/consume-sat-dag.py
@@ -13,7 +13,7 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils.trigger_rule import TriggerRule
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -120,9 +120,8 @@ def sat_consumer_dag() -> None:
                             + "}}",
             "SATCONS_WORKDIR": f"s3://nowcasting-sat-{env}/odegree",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The task {get_task_link()} failed to collect odegree satellite data. "
-            "The forecast will automatically move over to PVNET-ECMWF "
+        on_failure_callback=get_slack_message_callback(
+            additional_message_context=("The forecast will automatically move over to PVNET-ECMWF "
             "which doesn't need satellite data. "
             "The EUMETSAT status link for the RSS service (5 minute) is "
             "<https://masif.eumetsat.int/ossi/webpages/level3.html?ossi_level3_filename"
@@ -130,7 +129,8 @@ def sat_consumer_dag() -> None:
             "and the 0 degree (15 minute) which we use as a backup is "
             "<https://masif.eumetsat.int/ossi/webpages/level3.html?ossi_level3_filename"
             "=seviri_0deg_hr.json.html&ossi_level2_filename=seviri_0deg.html|here>. "
-            "No out-of-hours support is required.",
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -192,8 +192,11 @@ def gsp_forecast_pvnet_dag() -> None:
             "{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}",
         ),
         on_failure_callback=get_slack_message_callback(
-            additional_message_context="This was trying to check when PVNet and PVNet ECMWF only last ran ",
-            urgency=Urgency.SUBCRITICAL
+            additional_message_context=(
+             "This was trying to check when PVNet and "
+             "PVNet ECMWF only last ran ",
+            ),
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -179,7 +179,9 @@ def gsp_forecast_pvnet_dag() -> None:
         trigger_rule="one_failed",
         python_callable=check_forecast_status,
         on_success_callback=get_slack_message_callback(
+            flag="gb",
             additional_message_context="{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}",
+            urgency=Urgency.CRITICAL,
         ),
         on_failure_callback=get_slack_message_callback(
             additional_message_context=(

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -179,7 +179,7 @@ def gsp_forecast_pvnet_dag() -> None:
         trigger_rule="one_failed",
         python_callable=check_forecast_status,
         on_success_callback=get_slack_message_callback(
-            flag="gb",
+            country="gb",
             additional_message_context="{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}",
             urgency=Urgency.CRITICAL,
         ),

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -8,7 +8,12 @@ from airflow.decorators import dag
 from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.operators.python import PythonOperator
 
-from airflow_dags.plugins.callbacks.slack import Urgency, get_task_link, get_slack_message_callback, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import (
+    Urgency,
+    get_slack_message_callback,
+    get_task_link,
+    slack_message_callback,
+)
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -225,7 +230,7 @@ def national_forecast_dayahead_dag() -> None:
                 "This forecast is only a backup "
                 "Only needed if other forecasts have failed "
             ),
-            urgency=Urgency.SUBCRITICAL,                        
+            urgency=Urgency.SUBCRITICAL,
     ),
 )
 

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -179,14 +179,12 @@ def gsp_forecast_pvnet_dag() -> None:
         trigger_rule="one_failed",
         python_callable=check_forecast_status,
         on_success_callback=get_slack_message_callback(
-            country="gb",
             additional_message_context="{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}",
-            urgency=Urgency.CRITICAL,
         ),
         on_failure_callback=get_slack_message_callback(
             additional_message_context=(
              "This was trying to check when PVNet and "
-             "PVNet ECMWF only last ran ",
+             "PVNet ECMWF only last ran "
             ),
             urgency=Urgency.SUBCRITICAL,
         ),

--- a/src/airflow_dags/dags/uk/forecast-gsp-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-gsp-dag.py
@@ -191,9 +191,9 @@ def gsp_forecast_pvnet_dag() -> None:
         on_success_callback=slack_message_callback(
             "{{ti.xcom_pull(task_ids='check-forecast-gsps-last-run')}}",
         ),
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The task {get_task_link()} failed. "
-            "This was trying to check when PVNet and PVNet ECMWF only last ran",
+        on_failure_callback=get_slack_message_callback(
+            additional_message_context="This was trying to check when PVNet and PVNet ECMWF only last ran ",
+            urgency=Urgency.SUBCRITICAL
         ),
     )
 

--- a/src/airflow_dags/dags/uk/forecast-site-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-site-dag.py
@@ -95,7 +95,7 @@ def clean_site_db_dag() -> None:
     database_clean_op = EcsAutoRegisterRunTaskOperator(
         airflow_task_id="uk-clean-sitedb",
         container_def=sitedb_cleaner,
-        on_failure_callback=get_slack_message_callback(urgency=Urgency.SUBCRITICAL)
+        on_failure_callback=get_slack_message_callback(urgency=Urgency.SUBCRITICAL),
     )
 
     latest_only_op >> database_clean_op

--- a/src/airflow_dags/dags/uk/forecast-site-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-site-dag.py
@@ -6,7 +6,7 @@ import os
 from airflow.decorators import dag
 from airflow.operators.latest_only import LatestOnlyOperator
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -74,10 +74,7 @@ def site_forecast_dag() -> None:
     forecast_sites_op = EcsAutoRegisterRunTaskOperator(
         airflow_task_id="forecast-sites",
         container_def=site_forecaster,
-        on_failure_callback=slack_message_callback(
-            f"❌🇬🇧 The {get_task_link()} failed. "
-            "Please see run book for appropriate actions. ",
-        ),
+        on_failure_callback=get_slack_message_callback(),
     )
 
     latest_only_op >> forecast_sites_op
@@ -98,10 +95,7 @@ def clean_site_db_dag() -> None:
     database_clean_op = EcsAutoRegisterRunTaskOperator(
         airflow_task_id="uk-clean-sitedb",
         container_def=sitedb_cleaner,
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed, but it is non-critical. "
-            "No out of hours support is required.",
-        ),
+        on_failure_callback=get_slack_message_callback(urgency=Urgency.SUBCRITICAL)
     )
 
     latest_only_op >> database_clean_op

--- a/src/airflow_dags/dags/uk/forecast-site-nl-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-site-nl-dag.py
@@ -68,7 +68,7 @@ def nl_forecast_dag() -> None:
         },
         on_failure_callback=get_slack_message_callback(
             country="nl",
-            urgency=Urgency.SUBCRITICAL
+            urgency=Urgency.SUBCRITICAL,
         ),
     )
 

--- a/src/airflow_dags/dags/uk/forecast-site-nl-dag.py
+++ b/src/airflow_dags/dags/uk/forecast-site-nl-dag.py
@@ -6,7 +6,7 @@ import os
 from airflow.decorators import dag
 from airflow.operators.latest_only import LatestOnlyOperator
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -66,9 +66,9 @@ def nl_forecast_dag() -> None:
             # https://github.com/openclimatefix/ocf-infrastructure/issues/887
             "SAVE_BATCHES_DIR": f"s3://uk-national-forecaster-models-{env}/nl_pvnet_batches",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇳🇱 The {get_task_link()} failed. "
-            "Please see run book for appropriate actions.",
+        on_failure_callback=get_slack_message_callback(
+            country="nl",
+            urgency=Urgency.SUBCRITICAL
         ),
     )
 

--- a/src/airflow_dags/dags/uk/metrics-dag.py
+++ b/src/airflow_dags/dags/uk/metrics-dag.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from airflow.decorators import dag
 
-from airflow_dags.plugins.callbacks.slack import get_task_link, slack_message_callback
+from airflow_dags.plugins.callbacks.slack import Urgency, get_slack_message_callback
 from airflow_dags.plugins.operators.ecs_run_task_operator import (
     ContainerDefinition,
     EcsAutoRegisterRunTaskOperator,
@@ -60,11 +60,10 @@ def metrics_dag() -> None:
             "RUN_ME": "false",  # Disable ME calculations
             "LOGLEVEL": "DEBUG",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed, "
-            "but its ok. This task is not critical for live services. "
-            "No out of hours support is required.",
-        ),
+        on_failure_callback=get_slack_message_callback(
+                additional_message_context="This task is not critical for live services. ",
+                urgency=Urgency.SUBCRITICAL,
+                ),
     )
 
 
@@ -87,11 +86,10 @@ def me_dag() -> None:
             "RUN_ME": "true",  # Enable ME calculations
             "LOGLEVEL": "DEBUG",
         },
-        on_failure_callback=slack_message_callback(
-            f"⚠️🇬🇧 The {get_task_link()} failed, "
-            "but its ok. This task is not critical for live services. "
-            "No out of hours support is required.",
-        ),
+        on_failure_callback=get_slack_message_callback(
+                additional_message_context="This task is not critical for live services. ",
+                urgency=Urgency.SUBCRITICAL,
+                ),
     )
 
 

--- a/src/airflow_dags/plugins/callbacks/slack.py
+++ b/src/airflow_dags/plugins/callbacks/slack.py
@@ -34,7 +34,6 @@ def _build_message(
 ) -> str:
     """Return a sensible message for the given urgency."""
     if urgency == Urgency.CRITICAL:
-        print(additional_message_context, "additional_message_context!")
         return (
             f"❌{flag} The {task_link} failed. "
             + additional_message_context

--- a/src/airflow_dags/plugins/callbacks/slack.py
+++ b/src/airflow_dags/plugins/callbacks/slack.py
@@ -29,17 +29,6 @@ def get_task_link() -> str:
     # note we need 4 { so that after f-string its 2 { which is needed for airflow
     return f"<https://{url}/dags/{{{{ ti.dag_id }}}}|task {{{{ ti.task_id }}}}>"
 
-
-def slack_message_callback(message: str) -> list[BaseNotifier]:
-    """Send a slack message via the slack notifier."""
-    return [
-        send_slack_notification(
-            text=message,
-            channel=f"tech-ops-airflow-{env}",
-            username="Airflow",
-        ),
-    ]
-
 def _build_message(
     task_link: str, flag: str, urgency: Urgency, additional_message_context: str = "",
 ) -> str:
@@ -61,7 +50,7 @@ def get_slack_message_callback(
     country: str = "gb",
     urgency: Urgency = Urgency.CRITICAL,
     additional_message_context: str = "",
-) -> list["BaseNotifier"]:
+) -> list[BaseNotifier]:
     """Send a slack message via the slack notifier to channels based on urgency and country.
 
     Args:

--- a/src/airflow_dags/plugins/callbacks/slack.py
+++ b/src/airflow_dags/plugins/callbacks/slack.py
@@ -21,7 +21,7 @@ DEFAULT_FLAG = "🏳️"
 class Urgency(StrEnum):
     """Urgency levels for notifications."""
     CRITICAL = auto()
-    NON_CRITICAL = auto()
+    SUBCRITICAL = auto()
 
 
 def get_task_link() -> str:
@@ -54,7 +54,7 @@ def _build_message(
     return (
         f"⚠️{flag} The {task_link} failed, but it's ok. "
         + additional_message_context
-        + " No out of hours support is required."
+        + "No out of hours support is required."
     )
 
 def get_slack_message_callback(
@@ -79,7 +79,11 @@ def get_slack_message_callback(
     message = _build_message(task_link=task_link, flag=flag, urgency=urgency,
                              additional_message_context=additional_message_context)
 
-    channel = f"tech-ops-airflow-{env}-{urgency.value}"
+    # Split channels by urgency for prod
+    if env == "production":
+        channel = f"tech-ops-airflow-{env}-{urgency.value}"
+    else:
+        channel = f"tech-ops-airflow-{env}"
 
     notifier = send_slack_notification(
         text=message,

--- a/src/airflow_dags/plugins/callbacks/slack.py
+++ b/src/airflow_dags/plugins/callbacks/slack.py
@@ -34,6 +34,7 @@ def _build_message(
 ) -> str:
     """Return a sensible message for the given urgency."""
     if urgency == Urgency.CRITICAL:
+        print(additional_message_context, "additional_message_context!")
         return (
             f"❌{flag} The {task_link} failed. "
             + additional_message_context


### PR DESCRIPTION
# Pull Request
## Description
This follows on from https://github.com/openclimatefix/airflow-dags/pull/386 and finishes the changes to split slack notifications we get from errors to separate channels based on the urgency of the notification.

This also includes some refactoring to use a single function which a custom message can be passed in for as well as country and urgency level information.

Fixes https://github.com/openclimatefix/airflow-dags/issues/361 related to reducing noise in our slack alert channels

## How Has This Been Tested?
Currently from unit tests but also tested the first PR on dev and this was working as expected after the new channels were setup and also the slack bot activated within them   